### PR TITLE
do not send the entire joi error object

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,21 +21,21 @@
   },
   "homepage": "https://github.com/Financial-Times/n-user-api-client#readme",
   "devDependencies": {
-    "@financial-times/n-gage": "^1.19.12",
+    "@financial-times/n-gage": "^1.19.14",
     "@types/chai": "^4.1.2",
     "@types/joi": "^13.0.7",
-    "@types/mocha": "^2.2.48",
+    "@types/mocha": "^5.0.0",
     "@types/nock": "^9.1.2",
-    "@types/node": "^9.4.7",
-    "@types/ramda": "^0.25.20",
-    "@types/sinon": "^4.3.0",
+    "@types/node": "^9.6.2",
+    "@types/ramda": "^0.25.21",
+    "@types/sinon": "^4.3.1",
     "chai": "^4.1.2",
-    "mocha": "^5.0.4",
+    "mocha": "^5.0.5",
     "nock": "^9.2.3",
-    "sinon": "^4.4.6",
+    "sinon": "^4.5.0",
     "ts-node": "^5.0.1",
     "tslint": "^5.9.1",
-    "typescript": "^2.7.2"
+    "typescript": "^2.8.1"
   },
   "engines": {
     "node": "^8.9.4"

--- a/src/services/validation/consent-api.ts
+++ b/src/services/validation/consent-api.ts
@@ -9,7 +9,7 @@ const validationError = (error: Joi.ValidationError) =>
 		api: 'CONSENT_API',
 		action: 'REQUEST_BODY_VALIDATION',
 		statusCode: 400,
-		error,
+		error: error.details,
 		type: errorTypes.VALIDATION
 	});
 


### PR DESCRIPTION
This is very noisy. It's only `error.details` we care about, not the annotate function, e.g.
 🐿 v2.8.0