### PR TITLE
better user consent (platform api) errors

### DIFF
--- a/src/services/user-consent.ts
+++ b/src/services/user-consent.ts
@@ -122,7 +122,7 @@ export class UserConsent extends PlatformAPI {
 	): Promise<ConsentAPI.ConsentRecord> {
 		const payload = this.validateConsentRecord(consents);
 
-		// get the user's consent record, including version	
+		// get the user's consent record, including version
 		const {
 			version,
 			data: existingRecord

--- a/src/services/user-consent.ts
+++ b/src/services/user-consent.ts
@@ -20,10 +20,7 @@ export class UserConsent extends PlatformAPI {
 	private validateConsent(
 		consent: ConsentAPI.ConsentChannel
 	): ConsentAPI.ConsentChannel {
-		return ConsentValidator.validateConsent(
-			consent,
-			this.source
-		);
+		return ConsentValidator.validateConsent(consent, this.source);
 	}
 
 	private validateConsentRecord(
@@ -46,15 +43,20 @@ export class UserConsent extends PlatformAPI {
 		return data;
 	}
 
-	public async getConsentRecord(): Promise<ConsentAPI.ConsentRecord> {
+	public async getConsentRecord(
+		includeVersion: boolean = false
+	): Promise<ConsentAPI.ConsentRecord> {
 		const consents = (await this.request(
 			'GET',
 			`/${this.scope}`,
 			'Could not retrieve consent record'
 		)) as ConsentAPI.ConsentRecord;
 
-		const { data } = await (consents as any).json();
-		return data;
+		const { version, data } = await (consents as any).json();
+
+		return includeVersion
+			? { version, data }
+			: data;
 	}
 
 	public async createConsent(
@@ -118,8 +120,23 @@ export class UserConsent extends PlatformAPI {
 	public async updateConsentRecord(
 		consents: ConsentAPI.ConsentCategories
 	): Promise<ConsentAPI.ConsentRecord> {
-		let payload = this.validateConsentRecord(consents);
-		const { version, data: existingRecord } = await this.getConsentRecord();
+		const payload = this.validateConsentRecord(consents);
+
+		// get the user's consent record, including version	
+		const {
+			version,
+			data: existingRecord
+		} = await this.getConsentRecord(true);
+
+		let updatedConsentRecord = mergeDeepRight(existingRecord, payload);
+
+		for (let [category, categoryConsents] of Object.entries(existingRecord)) {
+			for (let [channel, channelConsent] of Object.entries(categoryConsents)) {
+				if (channelConsent.lbi === true) {
+					updatedConsentRecord[category][channel].lbi = true;
+				}
+			}
+		}
 
 		const updatedConsents = (await this.request(
 			'PUT',
@@ -128,7 +145,7 @@ export class UserConsent extends PlatformAPI {
 			{
 				body: JSON.stringify({
 					version,
-					data: mergeDeepRight(existingRecord, payload)
+					data: updatedConsentRecord
 				})
 			}
 		)) as ConsentAPI.ConsentRecord;

--- a/src/wrappers/platform-api.ts
+++ b/src/wrappers/platform-api.ts
@@ -69,11 +69,10 @@ export class PlatformAPI {
 			}
 			return response;
 		} catch (error) {
-			const e = new ErrorWithData(errorMsg, {
+			const e = new ErrorWithData(errorMsg, Object.assign({
 				api: 'MEMBERSHIP_PLATFORM',
-				url: `${this.url}${path}`,
-				error
-			});
+				url: `${this.url}${path}`
+			}, error.data ? error.data : error));
 			logger.error(e);
 			throw(e);
 		}

--- a/test/services/user-consent.spec.ts
+++ b/test/services/user-consent.spec.ts
@@ -62,6 +62,8 @@ describe('UserConsent - consent API wrapper', () => {
 				await api.validateConsent(consent);
 			} catch (error) {
 				expect(error).to.be.instanceof(ErrorWithData);
+				expect(error).to.haveOwnProperty('data');
+				expect(error.data).to.deep.include({ type: 'VALIDATION' });
 			}
 		});
 
@@ -110,11 +112,13 @@ describe('UserConsent - consent API wrapper', () => {
 		});
 
 		it('should throw a decorated error', async () => {
-			consentApi(`/${test.category}/${test.channel}`, 'get', 400);
+			consentApi(`/${test.category}/${test.channel}`, 'get', 404);
 			try {
 				await api.getConsent(test.category, test.channel);
 			} catch (error) {
 				expect(error).to.be.instanceof(ErrorWithData);
+				expect(error).to.haveOwnProperty('data');
+				expect(error.data).to.deep.include({ statusCode: 404 });
 			}
 		});
 	});
@@ -134,11 +138,13 @@ describe('UserConsent - consent API wrapper', () => {
 		});
 
 		it('should throw a decorated error', async () => {
-			consentApi('', 'get', 400);
+			consentApi('', 'get', 404);
 			try {
 				await api.getConsentRecord();
 			} catch (error) {
 				expect(error).to.be.instanceof(ErrorWithData);
+				expect(error).to.haveOwnProperty('data');
+				expect(error.data).to.deep.include({ statusCode: 404 });
 			}
 		});
 	});
@@ -160,11 +166,13 @@ describe('UserConsent - consent API wrapper', () => {
 		});
 
 		it('should throw a decorated error', async () => {
-			consentApi(`/${test.category}/${test.channel}`, 'post', 400);
+			consentApi(`/${test.category}/${test.channel}`, 'post', 404);
 			try {
 				await api.createConsent(test.category, test.channel, consentUnit);
 			} catch (error) {
 				expect(error).to.be.instanceof(ErrorWithData);
+				expect(error).to.haveOwnProperty('data');
+				expect(error.data).to.deep.include({ statusCode: 404 });
 			}
 		});
 	});
@@ -177,11 +185,13 @@ describe('UserConsent - consent API wrapper', () => {
 		});
 
 		it('should throw a decorated error', async () => {
-			consentApi('', 'post', 400);
+			consentApi('', 'post', 404);
 			try {
 				await api.createConsentRecord(consentRecord);
 			} catch (error) {
 				expect(error).to.be.instanceof(ErrorWithData);
+				expect(error).to.haveOwnProperty('data');
+				expect(error.data).to.deep.include({ statusCode: 404 });
 			}
 		});
 	});
@@ -203,11 +213,13 @@ describe('UserConsent - consent API wrapper', () => {
 		});
 
 		it('should throw a decorated error', async () => {
-			consentApi(`/${test.category}/${test.channel}`, 'patch', 400);
+			consentApi(`/${test.category}/${test.channel}`, 'patch', 404);
 			try {
 				await api.updateConsent(test.category, test.channel, consentUnit);
 			} catch (error) {
 				expect(error).to.be.instanceof(ErrorWithData);
+				expect(error).to.haveOwnProperty('data');
+				expect(error.data).to.deep.include({ statusCode: 404 });
 			}
 		});
 	});
@@ -278,11 +290,13 @@ describe('UserConsent - consent API wrapper', () => {
 		});
 
 		it('should throw a decorated error', async () => {
-			consentApi('', 'put', 400);
+			consentApi('', 'put', 404);
 			try {
 				await api.updateConsentRecord(payload);
 			} catch (error) {
 				expect(error).to.be.instanceof(ErrorWithData);
+				expect(error).to.haveOwnProperty('data');
+				expect(error.data).to.deep.include({ statusCode: 404 });
 			}
 		});
 	});

--- a/test/services/user-consent.spec.ts
+++ b/test/services/user-consent.spec.ts
@@ -212,7 +212,7 @@ describe('UserConsent - consent API wrapper', () => {
 		});
 	});
 
-	context.only('updateConsentRecord', () => {
+	context('updateConsentRecord', () => {
 		let payload;
 		
 		beforeEach(() => {

--- a/test/services/user-consent.spec.ts
+++ b/test/services/user-consent.spec.ts
@@ -214,7 +214,7 @@ describe('UserConsent - consent API wrapper', () => {
 
 	context('updateConsentRecord', () => {
 		let payload;
-		
+
 		beforeEach(() => {
 			consentApi('', 'get', 200, consentRecordResponse);
 			payload = {

--- a/test/services/user-consent.spec.ts
+++ b/test/services/user-consent.spec.ts
@@ -1,3 +1,4 @@
+import * as sinon from 'sinon';
 import { expect } from 'chai';
 import { mergeDeepRight } from 'ramda';
 import { consentApi } from '../nocks';
@@ -125,6 +126,13 @@ describe('UserConsent - consent API wrapper', () => {
 			expect(response).to.deep.equal(consentRecord);
 		});
 
+		it('should include version in the response if called with includeVersion = true', async () => {
+			consentApi('', 'get', 200, consentRecordResponse);
+			const response = await api.getConsentRecord(true);
+			const { version, data } = consentRecordResponse;
+			expect(response).to.deep.equal({ version, data });
+		});
+
 		it('should throw a decorated error', async () => {
 			consentApi('', 'get', 400);
 			try {
@@ -204,27 +212,69 @@ describe('UserConsent - consent API wrapper', () => {
 		});
 	});
 
-	context('updateConsentRecord', () => {
-		const payload = {
-			newCategory: {
-				newChannel: {
-					status: true,
-					lbi: true,
-					fow: 'string',
-					source: 'string'
+	context.only('updateConsentRecord', () => {
+		let payload;
+		
+		beforeEach(() => {
+			consentApi('', 'get', 200, consentRecordResponse);
+			payload = {
+				newCategory: {
+					newChannel: {
+						status: true,
+						lbi: true,
+						fow: 'string',
+						source: 'string'
+					}
 				}
-			}
-		};
-
-		const updatedConsentRecord = mergeDeepRight(consentRecordResponse, {
-			data: payload
+			};
 		});
 
 		it('should update the consent record for a user', async () => {
-			consentApi('', 'get', 200, consentRecordResponse);
+			const updatedConsentRecord = mergeDeepRight(consentRecordResponse, {
+				data: payload
+			});
 			consentApi('', 'put', 200, updatedConsentRecord);
 			const response = await api.updateConsentRecord(payload);
 			expect(response).to.deep.equal(updatedConsentRecord.data);
+		});
+
+		it('should not overwrite existing lbi=true', async () => {
+			consentApi('', 'put', 200, {});
+			const putRequestSpy = sinon
+				.spy(UserConsent.prototype, 'request')
+				.withArgs(
+					'PUT',
+					sinon.match.any,
+					sinon.match.any,
+					sinon.match.any
+				);
+
+			// build a payload based on the existing consent record
+			payload = JSON.parse(
+				JSON.stringify(
+					consentRecordResponse.data
+				)
+			);
+			// change the status to check for a correct update
+			payload.marketing.byEmail.status = false;
+
+			// request payload should have status = false
+			const expectedPayload = JSON.stringify({
+				version: consentRecordResponse.version,
+				data: payload
+			});
+
+			// lbi = false here should not overwrite lbi for the existing record
+			payload.marketing.byEmail.lbi = false;
+
+			await api.updateConsentRecord(payload);
+			expect(putRequestSpy.calledOnce).to.equal(true);
+			expect(putRequestSpy.calledWith(
+				'PUT',
+				sinon.match.any,
+				sinon.match.any,
+				{ body: expectedPayload }
+			)).to.equal(true);
 		});
 
 		it('should throw a decorated error', async () => {

--- a/test/wrappers/platform-api.spec.ts
+++ b/test/wrappers/platform-api.spec.ts
@@ -25,6 +25,8 @@ describe('PlatformAPI wrapper', () => {
 			new PlatformAPI('/', APIMode.Mock);
 		} catch (error) {
 			expect(error).to.be.instanceof(ErrorWithData);
+			expect(error).to.haveOwnProperty('data');
+			expect(error.data).to.deep.include({ variable: 'MEMBERSHIP_API_HOST_MOCK' });
 		}
 	});
 
@@ -34,6 +36,8 @@ describe('PlatformAPI wrapper', () => {
 			new PlatformAPI('/', APIMode.Mock);
 		} catch (error) {
 			expect(error).to.be.instanceof(ErrorWithData);
+			expect(error).to.haveOwnProperty('data');
+			expect(error.data).to.deep.include({ variable: 'MEMBERSHIP_API_KEY_MOCK' });
 		}
 	});
 
@@ -61,6 +65,8 @@ describe('PlatformAPI wrapper', () => {
 		} catch (error) {
 			expect(error).to.be.instanceof(ErrorWithData);
 			expect(error.message).to.equal('Error message');
+			expect(error).to.haveOwnProperty('data');
+			expect(error.data).to.deep.include({ statusCode: 400 });
 		}
 	});
 


### PR DESCRIPTION
Refactors the unhelpful pattern below and improves tests:
```
class PlatformAPI {
  method () {
    try {
      thing
    } catch (error) {
      throw ErrorWithData(msg, error);
    }
  }

  wrapsMethod() {
    try {
      method();
    } catch (error) {
      throw ErrorWithData(msg, error);
    }
  }
```
This is an unhelpful pattern because we end up with `error.data.error.data` for `wrapsMethod` errors.

Refactored version always supplies one `error.data` property including the properties from upstream errors.

Apologies for the random commit history, I should have rebased.