### PR TITLE
allow override request options for session-api

### DIFF
--- a/src/read/apis/session-service.ts
+++ b/src/read/apis/session-service.ts
@@ -2,17 +2,21 @@ import 'isomorphic-fetch';
 import { apiErrorType, ErrorWithData } from '../../utils/error';
 import { isSessionStale } from '../transforms/session-freshness';
 
-export const getSessionData = async ({ session, apiHost, apiKey }) => {
+export const getSessionData = async (
+	{ session, apiHost, apiKey },
+	requestOptions = {}
+) => {
 	const url = `${apiHost}/sessions/s/${session}`;
 	const errorMsg = 'Could not get session data';
-	const options = {
+	const options = Object.assign({
 		timeout: 10000,
 		headers: {
 			'Content-Type': 'application/json',
 			'X-Api-Key': apiKey
 		},
 		method: 'GET'
-	};
+	}, requestOptions);
+
 	const response = await fetch(url, options);
 	if (response.ok) {
 		const body = await response.json();

--- a/src/read/getUser.ts
+++ b/src/read/getUser.ts
@@ -7,7 +7,9 @@ import { ErrorWithData, errorTypes } from '../utils/error';
 import { getSessionData } from './apis/session-service';
 import { validateOptions } from '../utils/validate';
 
-export const getUserBySession = async (session: string): Promise<GraphQlUserApiResponse> => {
+export const getUserBySession = async (
+	session: string
+): Promise<GraphQlUserApiResponse> => {
 	const defaultErrorMessage = 'Unable to retrieve user';
 	const graphQlQuery = 'mma-user-by-session';
 	try {
@@ -29,9 +31,7 @@ export const getUserBySession = async (session: string): Promise<GraphQlUserApiR
 		const transformed = readTransforms(user);
 		return transformed;
 	} catch (error) {
-		const errorMsg = error.data
-			? error.message
-			: defaultErrorMessage;
+		const errorMsg = error.data ? error.message : defaultErrorMessage;
 
 		const e = new ErrorWithData(errorMsg, {
 			api: 'MEMBERSHIP_GRAPHQL',
@@ -43,7 +43,10 @@ export const getUserBySession = async (session: string): Promise<GraphQlUserApiR
 	}
 };
 
-export const getUserIdAndSessionData = async (opts): Promise<any> => {
+export const getUserIdAndSessionData = async (
+	opts,
+	requestOptions = {}
+): Promise<any> => {
 	validateOptions(opts, null, ['session', 'apiHost', 'apiKey']);
-	return await getSessionData(opts);
+	return await getSessionData(opts, requestOptions);
 };

--- a/test/getUser.spec.ts
+++ b/test/getUser.spec.ts
@@ -1,3 +1,5 @@
+import 'isomorphic-fetch';
+import * as sinon from 'sinon';
 import { expect } from 'chai';
 import { getUserBySession, getUserIdAndSessionData } from '../src/read/getUser';
 import { graphQlUserBySession, userIdBySession } from './nocks';
@@ -5,6 +7,18 @@ import { graphQlUserBySession, userIdBySession } from './nocks';
 describe('getUser', () => {
 	const session = '123';
 	let responseType;
+
+	let sandbox;
+	let fetchSpy;
+
+	beforeEach(() => {
+		sandbox = sinon.createSandbox();
+		fetchSpy = sandbox.spy(global, 'fetch');
+	});
+
+	afterEach(() => {
+		sandbox.restore();
+	});
 
 	describe('getUserBySession', () => {
 		it('resolves with a transformed user object when successful', async () => {
@@ -99,6 +113,12 @@ describe('getUser', () => {
 					expect(err.data.statusCode).to.equal(403);
 					expect(err.message).to.equal('Could not get session data');
 				});
+		});
+
+		it('allows overriding the underlying fetch request options', async () => {
+			userIdBySession({session: params.session});
+			const sessionData = await getUserIdAndSessionData(params, { timeout: 1 });
+			expect(fetchSpy.calledWith(sinon.match.any, sinon.match({ timeout: 1 }))).to.be.true;
 		});
 	});
 


### PR DESCRIPTION
**Background**
- `getUserIdAndSessionData` is used in the Consent Proxy Service to authenticate the `FTSession_s` cookie on incoming requests
- the main use cases for the above are all CORS requests to authenticated Consent Proxy Service endpoints (e.g. yes/no consent toggles in enhanced experience)
- reusing the connection pool for Session API in the Consent Proxy Service will make for a probably significant performance win

**Change**
Allow optionally overriding request options for Session API (with an optional argument for `getUserIdAndSessionData`).

**Example keep-alive perf gain**
<img width="370" alt="screen shot 2018-05-15 at 21 55 16" src="https://user-images.githubusercontent.com/12828487/40084978-dde7bc78-5890-11e8-9dda-43cc6a5567e5.png">
