### PR TITLE
Update to typescript@3 as we're using type unknown 🐿 v2.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "snyk": "^1.168.0",
     "ts-node": "^5.0.1",
     "tslint": "^5.10.0",
-    "typescript": "^2.8.3"
+    "typescript": "^3.9.6"
   },
   "engines": {
     "node": "^8.9.4"

--- a/src/read/getPayment.ts
+++ b/src/read/getPayment.ts
@@ -31,7 +31,7 @@ export const getPaymentDetailsBySession = async (
 		const paymentMethod = R.path(
 			['subscriber', 'billingAccount', 'paymentMethod'],
 			user
-		) as object;
+		) as Record<string, string | boolean>;
 		if (!paymentMethod) {
 			return null;
 		}

--- a/src/read/getPayment.ts
+++ b/src/read/getPayment.ts
@@ -31,7 +31,7 @@ export const getPaymentDetailsBySession = async (
 		const paymentMethod = R.path(
 			['subscriber', 'billingAccount', 'paymentMethod'],
 			user
-		);
+		) as object;
 		if (!paymentMethod) {
 			return null;
 		}

--- a/test/getUser.spec.ts
+++ b/test/getUser.spec.ts
@@ -3,6 +3,7 @@ import * as sinon from 'sinon';
 import { expect } from 'chai';
 import { getUserBySession, getUserIdAndSessionData } from '../src/read/getUser';
 import { graphQlUserBySession, userIdBySession } from './nocks';
+import { doesNotThrow } from 'assert';
 
 describe('getUser', () => {
 	const session = '123';
@@ -117,8 +118,10 @@ describe('getUser', () => {
 
 		it('allows overriding the underlying fetch request options', async () => {
 			userIdBySession({session: params.session});
-			const sessionData = await getUserIdAndSessionData(params, { timeout: 1 });
-			expect(fetchSpy.calledWith(sinon.match.any, sinon.match({ timeout: 1 }))).to.be.true;
+			const sessionData = await getUserIdAndSessionData(params, { timeout: 1 })
+				.catch(err => {
+					expect(fetchSpy.calledWith(sinon.match.any, sinon.match({ timeout: 1 }))).to.be.true;
+				});
 		});
 	});
 


### PR DESCRIPTION
## Description
Builds are broken because type `unknown` is not defined in typescript@2.
Updating the dependency to typescript@3 fixes this.