### PR TITLE
ADSDEV-1111: CI nightly: migrate scheduled workflow to scheduled pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,11 +154,10 @@ workflows:
             - test
 
   nightly:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            <<: *filters_only_main
+    when:
+      and:
+        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        - equal: [ "Nightly", << pipeline.schedule.name >> ]
     jobs:
       - build:
           context: next-nightly-build


### PR DESCRIPTION
Migrate CI nightly workflow from a scheduled workflow to a scheduled pipeline.

I followed the CircleCI guide [Migrate schedule workflows](https://circleci.com/docs/scheduled-pipelines#migrate-scheduled-workflows).

I tested the new scheduled pipeline by creating a new trigger called [Nightly trigger](https://app.circleci.com/settings/project/github/Financial-Times/n-user-api-client/triggers?return-to=https%3A%2F%2Fapp.circleci.com%2Fpipelines%2Fgithub%2FFinancial-Times%2Fn-user-api-client&success=true).

I've subsequently configured again the Nightly trigger to execute the workflow at every day at midnight.