### PR TITLE
Upgrade @financial-times/n-mask-logger 6.0.0 -> 7.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "typescript": "^3.9.6"
   },
   "dependencies": {
-    "@financial-times/n-mask-logger": "6.0.0",
+    "@financial-times/n-mask-logger": "7.2.0",
     "@financial-times/n-memb-gql-client": "2.2.3",
     "isomorphic-fetch": "^3.0.0",
     "querystring": "^0.2.0",


### PR DESCRIPTION
Re. this PR comment: https://github.com/Financial-Times/next-newsletter-signup/pull/360#discussion_r1113327947

Creating a release with this change will allow next-newsletter-signup to include the requisite version of n-logger in its dependency tree.

The only breaking changes in [n-mask-logger v7](https://github.com/Financial-Times/n-mask-logger/releases/tag/v7.0.0) for are dropped support for Node v12 and npm 6.