### PR TITLE
Move joi from dev dependencies to prod

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "@types/sinon": "^4.3.3",
     "chai": "^4.1.2",
     "check-engines": "1.5.0",
-    "joi": "10.6.0",
     "mocha": "^5.1.1",
     "nock": "^9.2.6",
     "sinon": "^5.0.7",
@@ -52,6 +51,7 @@
     "@financial-times/n-mask-logger": "7.2.0",
     "@financial-times/n-memb-gql-client": "2.2.3",
     "isomorphic-fetch": "^3.0.0",
+    "joi": "10.6.0",
     "querystring": "^0.2.0",
     "ramda": "^0.27.1",
     "url": "^0.11.0"


### PR DESCRIPTION
Joi is used by this library in production (e.g. [here](https://github.com/Financial-Times/n-user-api-client/blob/4809e14940fdf1d9f7476603c4a91a56aa47a5e6/src/validation/consent-api.ts#L4)) and it was accidentally moved into development dependencies [ages ago](https://github.com/Financial-Times/n-user-api-client/commit/911361f10a710788324f774f60c1178d78512b9f). This change made it into v4.1.0.

I spotted this when I tried to upgrade next-control-centre to use the latest version of this library - the app won't start because Joi is missing as a dependency. This resolves the issue.

Helps resolve [CPREL-518](https://financialtimes.atlassian.net/browse/CPREL-518)

[CPREL-518]: https://financialtimes.atlassian.net/browse/CPREL-518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ