### PR TITLE
Breaking: replace n-logger with Reliability Kit logger

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "typescript": "^3.9.6"
   },
   "dependencies": {
-    "@financial-times/n-mask-logger": "7.2.0",
+    "@dotcom-reliability-kit/logger": "^2.2.7",
     "@financial-times/n-memb-gql-client": "2.2.3",
     "isomorphic-fetch": "^3.0.0",
     "joi": "10.6.0",

--- a/src/types/n-mask-logger.d.ts
+++ b/src/types/n-mask-logger.d.ts
@@ -1,1 +1,0 @@
-declare module '@financial-times/n-mask-logger';

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,2 +1,8 @@
-import * as MaskLogger from '@financial-times/n-mask-logger';
-export const logger = new MaskLogger(['email', 'password']);
+import {Logger, transforms} from '@dotcom-reliability-kit/logger';
+export const logger = new Logger({
+	transforms: [
+		transforms.legacyMask({
+			denyList: ['email', 'password']
+		})
+	]
+});


### PR DESCRIPTION
This replaces n-logger usage with Reliability Kit logger. It's a breaking change because the module now logs to `stdout` rather than sending logs directly to Splunk. This should be a safe upgrade for most Customer Products apps.

If you're interested in the n-mask-logger API changes, [there's full documentation here](https://github.com/Financial-Times/dotcom-reliability-kit/blob/main/packages/logger/docs/migration.md#n-mask-logger-api-changes).