### PR TITLE
ADSDEV 1779: Remove reference to Node 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,11 +14,11 @@
   },
   "homepage": "https://github.com/Financial-Times/n-user-api-client#readme",
   "volta": {
-    "node": "18.17.1"
+    "node": "18.19.1"
   },
   "engines": {
-    "node": "16.x || 18.x",
-    "npm": "7.x || 8.x || 9.x"
+    "node": "18.x",
+    "npm": "8.x || 9.x || 10.x"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
## Description

This PR addresses the Cyber Essentials requirement to remove the reference to Node 16 from `package.json`